### PR TITLE
Don't delete the build folder evertime. Check if file was modified before rebuild it.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,4 @@ Check the end of `main.v` to know what is planned to be added to the project in 
 - Gather all the `.java` files and build them into a single jar file with `jake -b`
 - Run the final jar with `jake -br`
     - Can also specify args for the final jar with `jake -br [args]`
+- Only build source files that have been recently modified.


### PR DESCRIPTION
## Done:

Before this PR the tool would delete the built classes evertime we run `jake -b`. Now with the changes done, we include the current classpath ( with `example/jakefile.json:build_dir_path`) and check if the last modified time of the `source.java` is greater than the `built.class`. This improves compilation times of bigger projects and reduce the `javac` work.

## Example:

- Run `./jake -b` on the `example` folder.
- Modify the `Main.java` in the `examples/src` folder.
- Rerun `./jake -b`

```console
> Compile java files with javac:
	javac -cp ./build -d ./build  ./src/marco/test/Main.java
> Creating jar file test-1.0.0.jar:
	jar cfe test-1.0.0.jar marco.test.Main *
```

From the output you can see that only Main.java was compiled.
If none of the files have been modified than you get the following output:

``` console
> Nothing to build.
> Creating jar file test-1.0.0.jar:
	jar cfe test-1.0.0.jar marco.test.Main *
```