### PR TITLE
Remove old class files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin/
 .vscode/
 *.iml
 
+example/Subclass.java
 example/build
 example/.cache
 example/*.jar

--- a/src/java.v
+++ b/src/java.v
@@ -79,13 +79,15 @@ pub fn compile_tests(jake utils.JakeProject) {
 pub fn create_jar(jake utils.JakeProject) {
 	// 1. Cleanup old .class files that don't exist in .java form.
 	for built_source in os.walk_ext(jake.build_dir_path, 'class') {
-		// fixme 23/09/22: This makes the jar include Inner class files even if the main source doesn't exist
-		if built_source.contains('$') {
-			continue
-		}
 		src := built_source.replace('.class', '.java').replace(jake.build_dir_path, jake.src_dir_path)
-		if !os.exists(src) {
-			os.rm(built_source) or { panic('${err}') }
+		if built_source.contains('$') {
+			if !os.exists(src.split('$')[0] + '.java') {
+				os.rm(built_source) or { panic('${err}') }
+			}
+		} else {
+			if !os.exists(src) {
+				os.rm(built_source) or { panic('${err}') }
+			}
 		}
 	}
 


### PR DESCRIPTION
## Done:

If a source file like `Java.java` contains an inner class, the `src/java.v:create_jar` wouldn't remove the inner class files generated by the Javac compiler.

## Example:

```java
public class Main {
     public static class Inner {
     }
}
```

If we delete the Main.java the Inner class file, should be deleted as well.